### PR TITLE
don't have minimum-stability version yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ CockroachDB database driver for Laravel 5.4
 ### Step 1: Install Through Composer
 
 ```
-composer require 'nbj/cockroachdb-laravel'
+composer require nbj/cockroachdb-laravel:dev-master
 ```
 
 ### Step 2: Add the Service Provider


### PR DESCRIPTION
Could not find package nbj/cockroachdb-laravel at any version for your minimum-stability (stable). Check the package spelling or your minimum-stability