### PR TITLE
Fixing override method signature to be compatable with latest laravel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # cockroachdb-laravel
-CockroachDB database driver for Laravel 5
+CockroachDB database driver for Laravel 8
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "nbj/cockroachdb-laravel",
-    "description": "CockroachDB driver for Laravel 5.6",
+    "description": "CockroachDB driver for Laravel 8",
     "keywords": ["cockroach", "cockroachdb", "laravel"],
     "type": "package",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
             "email": "nbj@cego.dk"
         }
     ],
-    "require": {},
     "autoload": {
         "psr-4": {
             "Nbj\\": "src/"
@@ -24,5 +23,9 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "require-dev": {
+        "illuminate/database": "^8.32",
+        "illuminate/support": "^8.32"
+    }
 }

--- a/src/Cockroach/Grammar/Query/CockroachGrammar.php
+++ b/src/Cockroach/Grammar/Query/CockroachGrammar.php
@@ -119,12 +119,13 @@ class CockroachGrammar extends Grammar
     }
 
     /**
-     * Compile the columns for the update statement.
+     * Compile the columns for an update statement.
      *
-     * @param  array   $values
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
      * @return string
      */
-    protected function compileUpdateColumns($values)
+    protected function compileUpdateColumns(Builder $query, array $values)
     {
         // When gathering the columns for an update statement, we'll wrap each of the
         // columns and convert it to a parameter value. Then we will concatenate a


### PR DESCRIPTION
Hi @nbj,

Firstly, I'd like to thank you for creating this project. I believe there is a lot of potentials and I'd like to see CockroachDB natively supported in Laravel at some point in the future. 

As of a recent version of the Illuminate framework that laravel utilizes, a method signature has changed which in result has broken this library. This pull request attempts to fix that, or issue #23.

Thanks,
Ely Huaghie

P.S.  
Please consider adding test cases at some point in the future if you have the time., the state of this library could use testing to validate that the code is production-ready. 